### PR TITLE
Set search as default page and remove GitHub link from header

### DIFF
--- a/src/onthespot/resources/web/about.html
+++ b/src/onthespot/resources/web/about.html
@@ -10,7 +10,6 @@
     <body>
         <div class="header">
             <ul>
-                <li class="hide-on-mobile"><a href="https://github.com/justin025/onthespot/" target="_blank">OnTheSpot</a></li>
                 <li><a href="/search">Search</a></li>
                 <li><a href="/download_queue">Downloads</a></li>
                 <li><a href="/settings">Settings</a></li>

--- a/src/onthespot/resources/web/download_queue.html
+++ b/src/onthespot/resources/web/download_queue.html
@@ -476,7 +476,6 @@
 <body>
     <div class="header">
         <ul>
-            <li class="hide-on-mobile"><a href="https://github.com/justin025/onthespot/" target="_blank">OnTheSpot</a></li>
             <li><a href="/search">Search</a></li>
             <li><a class="active" href="/download_queue">Downloads</a></li>
             <li><a href="/settings">Settings</a></li>

--- a/src/onthespot/resources/web/search.html
+++ b/src/onthespot/resources/web/search.html
@@ -481,7 +481,6 @@
 <body>
     <div class="header">
         <ul>
-            <li class="hide-on-mobile"><a href="https://github.com/justin025/onthespot/" target="_blank">OnTheSpot</a></li>
             <li><a class="active" href="/search">Search</a></li>
             <li><a href="/download_queue">Downloads</a></li>
             <li><a href="/settings">Settings</a></li>

--- a/src/onthespot/resources/web/settings.html
+++ b/src/onthespot/resources/web/settings.html
@@ -450,7 +450,6 @@
 <body>
     <div class="header">
         <ul>
-            <li class="hide-on-mobile"><a href="https://github.com/justin025/onthespot/" target="_blank">OnTheSpot</a></li>
             <li><a href="/search">Search</a></li>
             <li><a href="/download_queue">Downloads</a></li>
             <li><a class="active" href="/settings">Settings</a></li>

--- a/src/onthespot/web.py
+++ b/src/onthespot/web.py
@@ -98,7 +98,7 @@ def login():
     if not config.get('use_webui_login') or not config.get('webui_username'):
         user = User('guest')
         login_user(user)
-        return redirect(url_for('download_queue_page'))
+        return redirect(url_for('search'))
 
     if request.method == 'POST':
         username = request.form['username']
@@ -106,7 +106,7 @@ def login():
         if username == config.get('webui_username') and password == config.get('webui_password'):
             user = User(username)
             login_user(user)
-            return redirect(url_for('download_queue_page'))
+            return redirect(url_for('search'))
         flash('Invalid credentials, please try again.')
     return render_template('login.html')
 
@@ -127,7 +127,7 @@ def serve_icons(filename):
 @app.route('/')
 @login_required
 def index():
-    return redirect(url_for('download_queue_page'))
+    return redirect(url_for('search'))
 
 
 @app.route('/search')


### PR DESCRIPTION
- Changed default page redirect from download_queue to search in web.py
- Updated login redirects to go to search page
- Removed GitHub link from navigation header in all HTML pages (search, about, download_queue, settings)