### PR TITLE
Fix layout issue after clearing/canceling/retrying downloads

### DIFF
--- a/src/onthespot/resources/web/download_queue.html
+++ b/src/onthespot/resources/web/download_queue.html
@@ -1002,19 +1002,34 @@
         function clearItems() {
             fetch('/api/clear_items', { method: 'POST' })
                 .then(response => response.json())
-                .then(data => data.success && console.log('Clear completed'));
+                .then(data => {
+                    if (data.success) {
+                        console.log('Clear completed');
+                        fetchItems();
+                    }
+                });
         }
 
         function cancelItems() {
             fetch('/api/cancel_items', { method: 'POST' })
                 .then(response => response.json())
-                .then(data => data.success && console.log('Cancel completed'));
+                .then(data => {
+                    if (data.success) {
+                        console.log('Cancel completed');
+                        fetchItems();
+                    }
+                });
         }
 
         function retryItems() {
             fetch('/api/retry_items', { method: 'POST' })
                 .then(response => response.json())
-                .then(data => data.success && console.log('Retry completed'));
+                .then(data => {
+                    if (data.success) {
+                        console.log('Retry completed');
+                        fetchItems();
+                    }
+                });
         }
 
         function restartWorkers() {


### PR DESCRIPTION
Added fetchItems() calls after clear, cancel, and retry operations to immediately refresh the UI instead of waiting for the next scheduled fetch