### PR TITLE
Fix column header alignment on mobile after clearing

### DIFF
--- a/src/onthespot/resources/web/download_queue.html
+++ b/src/onthespot/resources/web/download_queue.html
@@ -412,6 +412,12 @@
                 display: none !important;
             }
 
+            /* Mobile column widths - redistribute space without hidden columns */
+            .col-track { width: 50px; }
+            .col-name { width: auto; }
+            .col-status { width: 100px; }
+            .col-action { width: 80px; }
+
             /* Make name column take available space */
             .name-cell {
                 max-width: 120px;


### PR DESCRIPTION
Added mobile-specific column widths to properly redistribute table space when some columns are hidden, preventing STATUS and ACTION headers from misaligning