### PR TITLE
Use colgroup to enforce column widths and fix mobile alignment

### DIFF
--- a/src/onthespot/resources/web/download_queue.html
+++ b/src/onthespot/resources/web/download_queue.html
@@ -546,6 +546,20 @@
         <div class="table-wrapper">
             <div class="table-scroll">
                 <table>
+                    <colgroup>
+                        <col style="display: none;"> <!-- Local ID -->
+                        {% if config.show_download_thumbnails %}
+                        <col class="hide-on-mobile" style="width: 60px;"> <!-- Thumbnail -->
+                        {% endif %}
+                        <col style="width: 50px;"> <!-- # -->
+                        <col> <!-- Name - flexible -->
+                        <col class="hide-on-mobile" style="width: 15%;"> <!-- Album -->
+                        <col class="hide-on-tablet hide-on-mobile" style="width: 12%;"> <!-- By -->
+                        <col class="hide-on-mobile" style="width: 10%;"> <!-- Service -->
+                        <col style="width: 100px;"> <!-- Status -->
+                        <col class="hide-on-tablet hide-on-mobile" style="width: 15%;"> <!-- Progress -->
+                        <col style="width: 80px;"> <!-- Action -->
+                    </colgroup>
                     <thead>
                         <tr>
                             <th style="display: none;">Local ID</th>


### PR DESCRIPTION
- Added colgroup with col elements matching each table column
- Set explicit widths for Status (100px) and Action (80px) columns
- Col elements inherit hide-on-mobile classes to match thead
- Forces browser to maintain column widths even with empty tbody