### PR TITLE
Add automatic account rotation for failed downloads

### DIFF
--- a/src/onthespot/qt/dl_progressbtn.py
+++ b/src/onthespot/qt/dl_progressbtn.py
@@ -57,6 +57,9 @@ class DownloadActionsButtons(QWidget):
         download_queue[self.local_id]['item_status'] = "Waiting"
         download_queue[self.local_id]['gui']['status_label'].setText(self.tr("Waiting"))
         download_queue[self.local_id]['gui']['progress_bar'].setValue(0)
+        # Clear tried accounts to allow retry with any account
+        if 'tried_accounts' in download_queue[self.local_id]:
+            download_queue[self.local_id]['tried_accounts'] = set()
         self.retry_btn.hide()
         self.cancel_btn.show()
 

--- a/src/onthespot/qt/mainui.py
+++ b/src/onthespot/qt/mainui.py
@@ -575,6 +575,9 @@ class MainWindow(QMainWindow):
                         download_queue[local_id]['gui']['status_label'].setText(self.tr("Waiting"))
                         download_queue[local_id]['gui']["btn"]['cancel'].show()
                         download_queue[local_id]['gui']["btn"]['retry'].hide()
+                        # Clear tried accounts to allow retry with any account
+                        if 'tried_accounts' in download_queue[local_id]:
+                            download_queue[local_id]['tried_accounts'] = set()
                     row_count -= 1
                 self.update_table_visibility()
 

--- a/src/onthespot/resources/web/download_queue.html
+++ b/src/onthespot/resources/web/download_queue.html
@@ -198,7 +198,7 @@
         .col-album { width: 15%; min-width: 100px; }
         .col-by { width: 12%; min-width: 80px; }
         .col-service { width: 10%; min-width: 90px; }
-        .col-status { width: 12%; min-width: 100px; }
+        .col-status { width: 12%; min-width: 100px; text-align: center; }
         .col-progress { width: 15%; min-width: 120px; }
         .col-action { width: 10%; min-width: 80px; text-align: right; }
 
@@ -267,6 +267,7 @@
             display: flex;
             gap: 4px;
             flex-wrap: nowrap;
+            justify-content: flex-end;
         }
 
         .action-cell .download-action-button {
@@ -415,7 +416,7 @@
             /* Mobile column widths - redistribute space without hidden columns */
             .col-track { width: 50px; }
             .col-name { width: auto; }
-            .col-status { width: 100px; }
+            .col-status { width: 100px; text-align: center; }
             .col-action { width: 80px; text-align: right; }
 
             /* Make name column take available space */

--- a/src/onthespot/web.py
+++ b/src/onthespot/web.py
@@ -229,6 +229,9 @@ def retry_items():
             if item["item_status"] in ("Failed", "Cancelled"):
                 download_queue[local_id]['item_status'] = 'Waiting'
                 download_queue[local_id]['available'] = True
+                # Clear tried accounts to allow retry with any account
+                if 'tried_accounts' in download_queue[local_id]:
+                    download_queue[local_id]['tried_accounts'] = set()
     return jsonify(success=True)
 
 
@@ -266,6 +269,9 @@ def retry_item(local_id):
         if local_id in download_queue:
             download_queue[local_id]['item_status'] = 'Waiting'
             download_queue[local_id]['available'] = True
+            # Clear tried accounts to allow retry with any account
+            if 'tried_accounts' in download_queue[local_id]:
+                download_queue[local_id]['tried_accounts'] = set()
     return jsonify(success=True)
 
 


### PR DESCRIPTION
When a download fails, the system now automatically tries with a different account on retry instead of repeatedly using the same failing account.

Changes:
- Modified get_account_token() to accept exclude_accounts parameter
- Added tracking of tried accounts per download item
- All failure handlers now record failed accounts and force rotation
- Manual retry operations clear tried_accounts for fresh start
- After all accounts are exhausted, the system resets and tries again

This ensures that temporary account-specific issues (rate limits, quota, permissions) don't prevent downloads that might succeed with a different account.