### PR TITLE
Fix UnboundLocalError in download worker exception handler

### DIFF
--- a/src/onthespot/downloader.py
+++ b/src/onthespot/downloader.py
@@ -279,7 +279,6 @@ class DownloadWorker(QObject):
                     logger.error(f"Failed to fetch metadata for '{item_id}', Error: {str(e)}\nTraceback: {traceback.format_exc()}")
                     item['item_status'] = "Failed"
                     self.update_progress(item, self.tr("Failed") if self.gui else "Failed", 0)
-                    logger.info(f"DEBUG item_path from format_item_path: {item_path}")
                     self.readd_item_to_download_queue(item)
                     continue
 


### PR DESCRIPTION
Removes debug log statement that tried to access item_path variable after exception occurs. The item_path variable is only assigned inside the try block, so it doesn't exist when an exception occurs before that assignment, causing an UnboundLocalError.

This was causing a secondary exception that masked the actual error when metadata fetch failed.

Fixes: downloader.py:282