### PR TITLE
Increase default concurrent downloads to 2 and change default sort to…

### DIFF
--- a/src/onthespot/otsconfig.py
+++ b/src/onthespot/otsconfig.py
@@ -112,7 +112,7 @@ class Config:
             "download_delay": 3, # Seconds to wait before next download attempt
             "download_chunk_size": 50000, # Chunk size in bytes to download in
             "maximum_queue_workers": 1, # Maximum number of queue workers
-            "maximum_download_workers": 1, # Maximum number of download workers
+            "maximum_download_workers": 2, # Maximum number of download workers
             "enable_retry_worker": False, # Enable retry worker, automatically retries failed downloads after a set time
             "retry_worker_delay": 10, # Amount of time to wait before retrying failed downloads, in minutes
 

--- a/src/onthespot/resources/web/download_queue.html
+++ b/src/onthespot/resources/web/download_queue.html
@@ -615,7 +615,7 @@
         
         // ============= STATE MANAGEMENT =============
         let currentData = {};
-        let sortState = { key: "track_number", dir: "asc" };
+        let sortState = { key: "album_name", dir: "asc" };
         let fetchInterval = 500;
         let filtersVisible = false;
 


### PR DESCRIPTION
… album

Changes:
- Increased maximum_download_workers default from 1 to 2 to support multiple accounts
- Changed download queue default sort order from track_number to album_name for better organization

This allows users with multiple configured accounts to have concurrent downloads running, and provides a more intuitive default sorting by album when viewing the download queue.