### PR TITLE
Change default sort order to progress descending

### DIFF
--- a/src/onthespot/resources/web/download_queue.html
+++ b/src/onthespot/resources/web/download_queue.html
@@ -615,7 +615,7 @@
         
         // ============= STATE MANAGEMENT =============
         let currentData = {};
-        let sortState = { key: "album_name", dir: "asc" };
+        let sortState = { key: "progress", dir: "desc" };
         let fetchInterval = 500;
         let filtersVisible = false;
 


### PR DESCRIPTION
Updated the download queue default sort from album_name (ascending) to progress (descending) for better visibility of download progress.