### PR TITLE
Set default album download sorting to track number

### DIFF
--- a/src/onthespot/resources/web/download_queue.html
+++ b/src/onthespot/resources/web/download_queue.html
@@ -615,7 +615,7 @@
         
         // ============= STATE MANAGEMENT =============
         let currentData = {};
-        let sortState = { key: "progress", dir: "desc" };
+        let sortState = { key: "track_number", dir: "asc" };
         let fetchInterval = 500;
         let filtersVisible = false;
 


### PR DESCRIPTION
Changed the default sorting in the download queue from 'progress' (descending)
to 'track_number' (ascending). This ensures that when downloading albums, tracks
are automatically sorted by their track number in the correct order (1, 2, 3...).