### PR TITLE
Fix incomplete playlists caused by M3U write failures

### DIFF
--- a/src/onthespot/downloader.py
+++ b/src/onthespot/downloader.py
@@ -380,7 +380,11 @@ class DownloadWorker(QObject):
                                     if config.get('create_m3u_file') and item.get('parent_category') == 'playlist':
                                         item['item_status'] = 'Adding To M3U'
                                         self.update_progress(item, self.tr("Adding To M3U") if self.gui else "Adding To M3U", 99)
-                                        add_to_m3u_file(item, item_metadata)
+                                        try:
+                                            add_to_m3u_file(item, item_metadata)
+                                        except Exception as m3u_error:
+                                            logger.error(f"Failed to add item to M3U file: {str(m3u_error)}\nTraceback: {traceback.format_exc()}")
+                                            logger.warning("M3U write failed, but file download was successful and will not be deleted")
 
                                 if item['item_status'] in ('Downloading', 'Setting Thumbnail', 'Adding To M3U', 'Getting Lyrics'):
                                     self.update_progress(item, self.tr("Already Exists") if self.gui else "Already Exists", 100)
@@ -994,7 +998,11 @@ class DownloadWorker(QObject):
                         if config.get('create_m3u_file') and item.get('parent_category') == 'playlist':
                             item['item_status'] = 'Adding To M3U'
                             self.update_progress(item, self.tr("Adding To M3U") if self.gui else "Adding To M3U", 99)
-                            add_to_m3u_file(item, item_metadata)
+                            try:
+                                add_to_m3u_file(item, item_metadata)
+                            except Exception as m3u_error:
+                                logger.error(f"Failed to add item to M3U file: {str(m3u_error)}\nTraceback: {traceback.format_exc()}")
+                                logger.warning("M3U write failed, but file download was successful and will not be deleted")
 
                     # Video Formatting
                     elif item_type in ('movie', 'episode'):

--- a/src/onthespot/utils.py
+++ b/src/onthespot/utils.py
@@ -736,7 +736,7 @@ def add_to_m3u_file(item, item_metadata):
         playlist_number=item.get('playlist_number'),
     ).replace(config.get('metadata_separator'), config.get('extinf_separator'))
 
-    # Check if the item_path is already in the M3U file
+    # Check if the item is already in the M3U file
     with open(m3u_path, 'r', encoding='utf-8') as m3u_file:
         try:
             ext_length = round(int(item_metadata['length'])/1000)
@@ -744,11 +744,20 @@ def add_to_m3u_file(item, item_metadata):
             ext_length = '-1'
         m3u_item_header = f"#EXTINF:{ext_length}, {EXTINF}"
         m3u_contents = m3u_file.readlines()
-        if m3u_item_header not in [line.strip() for line in m3u_contents]:
+
+        # Check both header and file path to ensure the entry is complete and correct
+        already_exists = False
+        for i in range(len(m3u_contents) - 1):
+            if m3u_contents[i].strip() == m3u_item_header:
+                # Check if the next line contains the file path
+                if m3u_contents[i + 1].strip() == item['file_path']:
+                    already_exists = True
+                    logger.info(f"{item['file_path']} already exists in the M3U file.")
+                    break
+
+        if not already_exists:
             with open(m3u_path, 'a', encoding='utf-8') as m3u_file:
                 m3u_file.write(f"{m3u_item_header}\n{item['file_path']}\n")
-        else:
-            logger.info(f"{item['file_path']} already exists in the M3U file.")
 
 
 def strip_metadata(item):


### PR DESCRIPTION
This commit fixes a critical bug where successfully downloaded files were being deleted when M3U playlist file writing failed, resulting in incomplete playlists.

Key fixes:
1. Separated M3U write error handling from download error handling
   - M3U write operations now have their own try-except blocks
   - M3U write failures no longer trigger file deletion
   - Downloads are marked successful even if M3U write fails

2. Improved M3U deduplication logic
   - Now checks both EXTINF header AND file path for duplicates
   - Prevents incomplete or duplicate entries in playlist files
   - More robust handling of retry scenarios

The root cause was that add_to_m3u_file() exceptions were caught by the outer download exception handler, which assumed the download failed and deleted all files. Now M3U failures are logged separately without affecting the downloaded files.

Fixes: Incomplete playlists from failed files or retries