### PR TITLE
Fix status buttons overflow in web browser

### DIFF
--- a/src/onthespot/resources/web/download_queue.html
+++ b/src/onthespot/resources/web/download_queue.html
@@ -66,6 +66,7 @@
             display: flex;
             align-items: center;
             gap: 10px;
+            flex-shrink: 0;
         }
 
         .status-dot {
@@ -92,6 +93,9 @@
             display: flex;
             gap: 8px;
             flex-wrap: wrap;
+            flex-shrink: 1;
+            min-width: 0;
+            justify-content: flex-end;
         }
 
         .action-buttons button {
@@ -99,6 +103,7 @@
             font-size: 12px;
             margin: 0;
             white-space: nowrap;
+            flex-shrink: 0;
         }
 
         /* Filters panel */
@@ -366,7 +371,16 @@
         }
 
         /* ============= RESPONSIVE BREAKPOINTS ============= */
-        
+
+        /* Medium desktop screens - compact buttons before mobile layout */
+        @media screen and (max-width: 1200px) {
+            .action-buttons button {
+                padding: 6px 10px;
+                font-size: 11px;
+                gap: 6px;
+            }
+        }
+
         /* Tablet */
         @media screen and (max-width: 900px) {
             .hide-on-tablet {


### PR DESCRIPTION
Resolves overflow issue where status buttons (Clear Done, Cancel All, Retry Failed, Restart) would overflow their container in web browsers at medium screen widths.

Changes:
- Added flex-shrink and min-width to action-buttons container for proper wrapping
- Added justify-content: flex-end to keep buttons right-aligned when wrapped
- Added responsive breakpoint at 1200px to compact buttons before mobile layout
- Set flex-shrink: 0 on status-info to prevent text from being squeezed

The buttons now properly wrap to a new line when space is constrained, and become more compact on medium-sized screens for better usability.