### PR TITLE
Force Spotify account reconnection before retrying failed downloads

### DIFF
--- a/src/onthespot/downloader.py
+++ b/src/onthespot/downloader.py
@@ -45,10 +45,38 @@ class RetryWorker(QObject):
     def run(self):
         while self.is_running:
             if download_queue:
+                # First, check if there are any failed downloads
+                has_failed_downloads = False
                 with download_queue_lock:
                     for local_id in download_queue.keys():
-                        logger.debug(f'Retrying : {local_id}')
                         if download_queue[local_id]['item_status'] == "Failed":
+                            has_failed_downloads = True
+                            break
+
+                # If there are failed downloads, force reconnect all Spotify accounts
+                if has_failed_downloads:
+                    logger.info("Found failed downloads - forcing Spotify account reconnection before retry")
+                    from .api.spotify import spotify_re_init_session
+
+                    reconnected_count = 0
+                    for account_idx, account in enumerate(account_pool):
+                        if account.get('service') == 'spotify' and account.get('login', {}).get('session'):
+                            try:
+                                logger.info(f"Reconnecting Spotify account {account_idx}: {account.get('username', 'unknown')}")
+                                spotify_re_init_session(account)
+                                account['last_session_time'] = time.time()
+                                reconnected_count += 1
+                            except Exception as e:
+                                logger.error(f"Failed to reconnect Spotify account {account_idx}: {e}")
+
+                    if reconnected_count > 0:
+                        logger.info(f"Successfully reconnected {reconnected_count} Spotify account(s) - now retrying failed downloads")
+
+                # Now retry the failed downloads
+                with download_queue_lock:
+                    for local_id in download_queue.keys():
+                        if download_queue[local_id]['item_status'] == "Failed":
+                            logger.debug(f'Retrying : {local_id}')
                             download_queue[local_id]['item_status'] = "Waiting"
                             if self.gui:
                                 download_queue[local_id]['gui']['status_label'].setText(self.tr("Waiting"))

--- a/src/onthespot/qt/mainui.py
+++ b/src/onthespot/qt/mainui.py
@@ -565,6 +565,34 @@ class MainWindow(QMainWindow):
 
 
     def retry_cancelled_and_failed_downloads(self):
+        # First, check if there are any failed downloads
+        has_failed_downloads = False
+        with download_queue_lock:
+            for local_id in download_queue.keys():
+                if download_queue[local_id]['item_status'] in ("Failed", "Cancelled"):
+                    has_failed_downloads = True
+                    break
+
+        # If there are failed downloads, force reconnect all Spotify accounts
+        if has_failed_downloads:
+            logger.info("Found failed downloads - forcing Spotify account reconnection before retry")
+            from ..api.spotify import spotify_re_init_session
+
+            reconnected_count = 0
+            for account_idx, account in enumerate(account_pool):
+                if account.get('service') == 'spotify' and account.get('login', {}).get('session'):
+                    try:
+                        logger.info(f"Reconnecting Spotify account {account_idx}: {account.get('username', 'unknown')}")
+                        spotify_re_init_session(account)
+                        account['last_session_time'] = time.time()
+                        reconnected_count += 1
+                    except Exception as e:
+                        logger.error(f"Failed to reconnect Spotify account {account_idx}: {e}")
+
+            if reconnected_count > 0:
+                logger.info(f"Successfully reconnected {reconnected_count} Spotify account(s) - now retrying failed downloads")
+
+        # Now retry the failed/cancelled downloads
         with download_queue_lock:
             row_count = self.tbl_dl_progress.rowCount()
             while row_count > 0:


### PR DESCRIPTION
Problem:
- When downloads fail due to stale/broken Spotify sessions, the retry
  mechanism only resets the item status to "Waiting" without reconnecting
- This causes the same stale session to be reused, leading to repeated failures
- Users must manually click "Restart Workers" to get fresh sessions

Solution:
- Modified RetryWorker to force reconnect all Spotify accounts before retrying
- Updated manual "Retry Failed" button (both Web and Qt GUI) to do the same
- Uses spotify_re_init_session() to perform "nuclear" session reset
- Logs reconnection attempts and success count for visibility

Changes:
- src/onthespot/downloader.py: RetryWorker.run() now reconnects Spotify accounts
- src/onthespot/web.py: retry_items() endpoint now reconnects before retry
- src/onthespot/qt/mainui.py: retry_cancelled_and_failed_downloads() now reconnects

This gives users the benefits of "Restart Workers" (fresh sessions) without
the overhead of a full application restart.